### PR TITLE
feat(auth): Introduce simple Machine-to-Machine (M2M) authentication using JWT

### DIFF
--- a/backend/CompanyService.Api/Auth/ITokenService.cs
+++ b/backend/CompanyService.Api/Auth/ITokenService.cs
@@ -1,0 +1,11 @@
+﻿using CompanyService.Api.Models;
+using CompanyService.Core.Models;
+using CompanyService.Domain.Errors;
+
+namespace CompanyService.Api.Auth
+{
+    public interface ITokenService
+    {
+        Result<CompanyError, TokenResponse> GetToken(TokenRequest request);
+    }
+}

--- a/backend/CompanyService.Api/Auth/MachineClients.cs
+++ b/backend/CompanyService.Api/Auth/MachineClients.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using CompanyService.Core.Common;
+using CompanyService.Core.Models;
+using CompanyService.Domain.Errors;
+
+namespace CompanyService.Api.Auth
+{
+    /// <summary>
+    /// Dummy implementation of machine-to-machine authentication store.
+    /// In a real-world scenario, client credentials would be stored securely in a database or an identity provider.
+    /// </summary>
+    public static class MachineClients
+    {
+        private static readonly Dictionary<string, string> _clients = new ()
+        {
+            { "client-id-123", "client-secret-abc" },
+            { "another-client", "another-secret" } 
+        };
+
+        public static Result<CompanyError> ValidateClient(string clientId, string clientSecret)
+        {
+            clientId.ThrowIfNullOrWhiteSpace(nameof(clientId));
+            clientSecret.ThrowIfNullOrWhiteSpace(nameof(clientSecret));
+
+            if (_clients.TryGetValue(clientId, out var storedSecret) && storedSecret == clientSecret)
+            {
+                return Result<CompanyError>.Ok();
+            }
+
+            return Result<CompanyError>.Fail(CompanyError.InvalidClientCredentials);
+        }
+    }
+}

--- a/backend/CompanyService.Api/Auth/TokenService.cs
+++ b/backend/CompanyService.Api/Auth/TokenService.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using CompanyService.Api.Models;
+using CompanyService.Core.Common;
+using CompanyService.Core.Models;
+using CompanyService.Core.Web.Configurations;
+using CompanyService.Domain.Errors;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+
+namespace CompanyService.Api.Auth
+{
+    public sealed class TokenService : ITokenService
+    {
+        private const string ClientIdClaim = "client_id";
+
+        private readonly ILogger<TokenService> _logger;
+        private readonly WebAppConfiguration _webAppConfiguration;
+
+        public TokenService(ILogger<TokenService> logger, WebAppConfiguration webAppConfiguration)
+        {
+            logger.ThrowIfNull();
+            webAppConfiguration.ThrowIfNull();
+
+            _logger = logger;
+            _webAppConfiguration = webAppConfiguration;
+        }
+
+        /// <summary>
+        /// Generates a JWT token if valid client credentials are provided.
+        /// In a real-world scenario, this would involve database checks and refresh tokens.
+        /// </summary>
+        /// <returns>JWT token.</returns>
+        public Result<CompanyError, TokenResponse> GetToken(TokenRequest request)
+        {
+            request.ThrowIfNull();
+
+            _logger.LogInformation("Generating token for client ID: {ClientId}", request.ClientId);
+
+            if (!_webAppConfiguration.AuthConfiguration.Enabled)
+            {
+                return Result<CompanyError>.Fail<TokenResponse>(CompanyError.AuthDisabled);
+            }
+
+            var result = MachineClients.ValidateClient(request.ClientId, request.ClientSecret);
+
+            if (result.Failed)
+            {
+                return Result<CompanyError>.Fail<TokenResponse>(result.Error!);
+            }
+
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var key = Encoding.UTF8.GetBytes(_webAppConfiguration.AuthConfiguration.JwtSecret!);
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(new[]
+                {
+                    new Claim(ClientIdClaim, request.ClientId)
+                }),
+                Expires = DateTime.UtcNow.AddHours(1),
+                SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256)
+            };
+
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+            return Result<CompanyError>.Ok(new TokenResponse(tokenHandler.WriteToken(token)));
+        }
+    }
+}

--- a/backend/CompanyService.Api/Controllers/AuthController.cs
+++ b/backend/CompanyService.Api/Controllers/AuthController.cs
@@ -1,0 +1,35 @@
+﻿using CompanyService.Api.Auth;
+using CompanyService.Api.Models;
+using CompanyService.Api.Utils;
+using CompanyService.Core.Common;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace CompanyService.Api.Controllers
+{
+    [Route(ApiConstants.AuthEndpoint)]
+    public sealed class AuthController : CompanyControllerBase
+    {
+        private readonly ILogger<AuthController> _logger;
+        private readonly ITokenService _tokenService;
+
+        public AuthController(ILogger<AuthController> logger, ITokenService tokenService)
+        {
+            logger.ThrowIfNull();
+            tokenService.ThrowIfNull();
+
+            _logger = logger;
+            _tokenService = tokenService;
+        }
+
+        [HttpPost(ApiConstants.TokenRoute)]
+        public ActionResult<TokenResponse> GetToken([FromBody] TokenRequest request)
+        {
+            request.ThrowIfNull();
+
+            _logger.LogInformation("Generating token for client ID: {ClientId}", request.ClientId);
+
+            return HandleResult(_tokenService.GetToken(request), (resp) => resp);
+        }
+    }
+}

--- a/backend/CompanyService.Api/Controllers/CompanyController.cs
+++ b/backend/CompanyService.Api/Controllers/CompanyController.cs
@@ -10,112 +10,115 @@ using CompanyService.Core.Validation.Attributes;
 using CompanyService.Domain.Errors;
 using CompanyService.Domain.Models;
 using CompanyService.Domain.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
-namespace CompanyService.Api.Controllers;
-
-[Route(ApiConstants.CompanyEndpoint)]
-public class CompanyController : CompanyControllerBase
+namespace CompanyService.Api.Controllers
 {
-    private readonly ILogger<CompanyController> _logger;
-    private readonly ICompanyManagerService _companyManagerService;
-
-    public CompanyController(
-        ILogger<CompanyController> logger,
-        ICompanyManagerService companyManagerService)
+    [Authorize]
+    [Route(ApiConstants.CompanyEndpoint)]
+    public sealed class CompanyController : CompanyControllerBase
     {
-        logger.ThrowIfNull();
-        companyManagerService.ThrowIfNull();
+        private readonly ILogger<CompanyController> _logger;
+        private readonly ICompanyManagerService _companyManagerService;
 
-        _logger = logger;
-        _companyManagerService = companyManagerService;
-    }
-
-    [HttpGet(ApiConstants.CompanyIdRoute)]
-    public async Task<ActionResult<CompanyApi>> GetCompanyByIdAsync(
-        [NotEmptyGuid] Guid id, CancellationToken cancellationToken)
-    {
-        _logger.LogInformation("Retrieving company by ID: {CompanyId}", id);
-
-        var result = await _companyManagerService.GetCompanyByIdAsync(id, cancellationToken);
-
-        return HandleResult(result, DomainToApiMapper.Map);
-    }
-
-    [HttpGet(ApiConstants.CompanyByIsinRoute)]
-    public async Task<ActionResult<CompanyApi>> GetCompanyByIsinAsync(
-        [FromQuery] IsinApi isin, CancellationToken cancellationToken)
-    {
-        _logger.LogInformation("Retrieving company by ISIN: {Isin}", isin.Value);
-
-        var result = await _companyManagerService.GetCompanyByIsinAsync(isin.Value, cancellationToken);
-
-        return HandleResult(result, DomainToApiMapper.Map);
-    }
-
-    [HttpGet]
-    public async Task<ActionResult<Page<CompanyApi>>> GetCompaniesAsync(
-        [FromQuery] GetCompaniesApiRequest request, CancellationToken cancellationToken)
-    {
-        _logger.LogInformation("Retrieving companies with request: {@Request}", request);
-
-        var companiesRequestResult = CreateGetCompaniesRequest(request);
-
-        if (companiesRequestResult.Failed)
+        public CompanyController(
+            ILogger<CompanyController> logger,
+            ICompanyManagerService companyManagerService)
         {
-            return HandleResult(companiesRequestResult);
+            logger.ThrowIfNull();
+            companyManagerService.ThrowIfNull();
+
+            _logger = logger;
+            _companyManagerService = companyManagerService;
         }
 
-        var result = await _companyManagerService.GetCompaniesAsync(companiesRequestResult.Value, cancellationToken);
-
-        return HandleResult(result, DomainToApiMapper.Map);
-    }
-
-    [HttpPost]
-    public async Task<ActionResult<CompanyApi>> CreateCompanyAsync(
-        [FromBody] CreateCompanyApiRequest request, CancellationToken cancellationToken)
-    {
-        _logger.LogInformation("Creating company: {@Request}", request);
-
-        var result = await _companyManagerService.CreateCompanyAsync(ApiToDomainMapper.Map(request), cancellationToken);
-
-        return HandleResult(result, DomainToApiMapper.Map);
-    }
-
-    [HttpPut(ApiConstants.CompanyIdRoute)]
-    public async Task<ActionResult<CompanyApi>> UpdateCompanyAsync(
-        [NotEmptyGuid] Guid id,
-        [FromBody] UpdateCompanyApiRequest request,
-        CancellationToken cancellationToken)
-    {
-        _logger.LogInformation("Updating company {CompanyId}: {@Request}", id, request);
-
-        var result = await _companyManagerService.UpdateCompanyAsync(id, ApiToDomainMapper.Map(request), cancellationToken);
-        
-        return HandleResult(result, DomainToApiMapper.Map);
-    }
-
-    private Result<CompanyError, GetCompaniesRequest> CreateGetCompaniesRequest(GetCompaniesApiRequest request)
-    {
-        var filter = default(CompanyFilter);
-
-        if (request.Filter != null)
+        [HttpGet(ApiConstants.CompanyIdRoute)]
+        public async Task<ActionResult<CompanyApi>> GetCompanyByIdAsync(
+            [NotEmptyGuid] Guid id, CancellationToken cancellationToken)
         {
-            var filterResult = CompanyFilter.Create(request.Filter.Name, request.Filter.Exchange, request.Filter.Ticker, request.Filter.Isin?.Value);
+            _logger.LogInformation("Retrieving company by ID: {CompanyId}", id);
 
-            if (filterResult.Failed)
+            var result = await _companyManagerService.GetCompanyByIdAsync(id, cancellationToken);
+
+            return HandleResult(result, DomainToApiMapper.Map);
+        }
+
+        [HttpGet(ApiConstants.CompanyByIsinRoute)]
+        public async Task<ActionResult<CompanyApi>> GetCompanyByIsinAsync(
+            [FromQuery] IsinApi isin, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Retrieving company by ISIN: {Isin}", isin.Value);
+
+            var result = await _companyManagerService.GetCompanyByIsinAsync(isin.Value, cancellationToken);
+
+            return HandleResult(result, DomainToApiMapper.Map);
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<Page<CompanyApi>>> GetCompaniesAsync(
+            [FromQuery] GetCompaniesApiRequest request, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Retrieving companies with request: {@Request}", request);
+
+            var companiesRequestResult = CreateGetCompaniesRequest(request);
+
+            if (companiesRequestResult.Failed)
             {
-                return Result<CompanyError>.Fail<GetCompaniesRequest>(filterResult.Error!);
+                return HandleResult(companiesRequestResult);
             }
 
-            filter = filterResult.Value;
+            var result = await _companyManagerService.GetCompaniesAsync(companiesRequestResult.Value, cancellationToken);
+
+            return HandleResult(result, DomainToApiMapper.Map);
         }
 
-        return GetCompaniesRequest.Create(
-            pageNumber: request.PageNumber,
-            filter: filter,
-            sortOrder: request.SortOrder,
-            pageSize: request.PageSize);
+        [HttpPost]
+        public async Task<ActionResult<CompanyApi>> CreateCompanyAsync(
+            [FromBody] CreateCompanyApiRequest request, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Creating company: {@Request}", request);
+
+            var result = await _companyManagerService.CreateCompanyAsync(ApiToDomainMapper.Map(request), cancellationToken);
+
+            return HandleResult(result, DomainToApiMapper.Map);
+        }
+
+        [HttpPut(ApiConstants.CompanyIdRoute)]
+        public async Task<ActionResult<CompanyApi>> UpdateCompanyAsync(
+            [NotEmptyGuid] Guid id,
+            [FromBody] UpdateCompanyApiRequest request,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Updating company {CompanyId}: {@Request}", id, request);
+
+            var result = await _companyManagerService.UpdateCompanyAsync(id, ApiToDomainMapper.Map(request), cancellationToken);
+
+            return HandleResult(result, DomainToApiMapper.Map);
+        }
+
+        private Result<CompanyError, GetCompaniesRequest> CreateGetCompaniesRequest(GetCompaniesApiRequest request)
+        {
+            var filter = default(CompanyFilter);
+
+            if (request.Filter != null)
+            {
+                var filterResult = CompanyFilter.Create(request.Filter.Name, request.Filter.Exchange, request.Filter.Ticker, request.Filter.Isin?.Value);
+
+                if (filterResult.Failed)
+                {
+                    return Result<CompanyError>.Fail<GetCompaniesRequest>(filterResult.Error!);
+                }
+
+                filter = filterResult.Value;
+            }
+
+            return GetCompaniesRequest.Create(
+                pageNumber: request.PageNumber,
+                filter: filter,
+                sortOrder: request.SortOrder,
+                pageSize: request.PageSize);
+        }
     }
 }

--- a/backend/CompanyService.Api/Controllers/CompanyControllerBase.cs
+++ b/backend/CompanyService.Api/Controllers/CompanyControllerBase.cs
@@ -45,6 +45,7 @@ namespace CompanyService.Api.Controllers
                 CompanyErrorCode.InvalidIsinCheckDigit => BadRequest("Invalid ISIN check digit."),
                 CompanyErrorCode.InvalidExchange => BadRequest("Invalid exchange."),
                 CompanyErrorCode.UnknownExchange => BadRequest("Unknown exchange."),
+                CompanyErrorCode.InvalidClientCredentials => Unauthorized("Invalid client credentials."),
                 _ => StatusCode(500, "An error occurred while processing the request.")
             };
         }

--- a/backend/CompanyService.Api/Models/TokenRequest.cs
+++ b/backend/CompanyService.Api/Models/TokenRequest.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace CompanyService.Api.Models
+{
+    public record TokenRequest(
+        [Required]
+        string ClientId,
+
+        [Required]
+        string ClientSecret);
+}

--- a/backend/CompanyService.Api/Models/TokenResponse.cs
+++ b/backend/CompanyService.Api/Models/TokenResponse.cs
@@ -1,0 +1,4 @@
+﻿namespace CompanyService.Api.Models
+{
+    public sealed record TokenResponse(string Token);
+}

--- a/backend/CompanyService.Api/Program.cs
+++ b/backend/CompanyService.Api/Program.cs
@@ -1,7 +1,9 @@
+using CompanyService.Api.Auth;
 using CompanyService.Application;
 using CompanyService.Core.Web;
 using CompanyService.Domain.Extensions;
 using CompanyService.Persistence.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 await CompanyCoreApiService
     .Create()
@@ -10,5 +12,6 @@ await CompanyCoreApiService
         services.AddDomain();
         services.AddPersistence(configuration);
         services.AddApplication();
+        services.AddScoped<ITokenService, TokenService>();
     })
     .RunAsync();

--- a/backend/CompanyService.Api/Utils/ApiConstants.cs
+++ b/backend/CompanyService.Api/Utils/ApiConstants.cs
@@ -3,8 +3,10 @@
     public static class ApiConstants
     {
         public const string CompanyEndpoint = "api/companies";
+        public const string AuthEndpoint = "api/auth";
 
         public const string CompanyIdRoute = "{id}";
         public const string CompanyByIsinRoute = "isin";
+        public const string TokenRoute = "token";
     }
 }

--- a/backend/CompanyService.Api/appsettings.Development.json
+++ b/backend/CompanyService.Api/appsettings.Development.json
@@ -32,7 +32,10 @@
     "Name": "Company Core Service"
   },
   "WebAppConfiguration": {
-    "AuthenticationEnabled": "true",
+    "AuthConfiguration": {
+      "Enabled": true,
+      "JwtSecret": "supersecretkey_supersecretkey_supersecretkey" // should be resolved from key vault in real world scenario
+    },
     "ApiConfiguration": {
       "Name": "Company Core Service API",
       "Version": "v1"

--- a/backend/CompanyService.Core/Web/CompanyCoreApiService.cs
+++ b/backend/CompanyService.Core/Web/CompanyCoreApiService.cs
@@ -112,6 +112,7 @@ namespace CompanyService.Core.Web
 
             services.AddSwagger(appConfiguration);
             services.AddProblemDetails();
+            services.AddAuthentication(appConfiguration);
 
             _configureCustomServices?.Invoke(services, configuration);
         }

--- a/backend/CompanyService.Core/Web/Configurations/AuthConfiguration.cs
+++ b/backend/CompanyService.Core/Web/Configurations/AuthConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using CompanyService.Core.Configurations.Validation;
+
+namespace CompanyService.Core.Web.Configurations
+{
+    public sealed class AuthConfiguration : IValidatableConfiguration, IValidatableObject
+    {
+        public bool Enabled { get; init; }
+
+        public string? JwtSecret { get; init; } = default;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (Enabled && string.IsNullOrWhiteSpace(JwtSecret))
+            {
+                yield return new ValidationResult("JwtSecret is required when AuthenticationEnabled is true", new[] { nameof(JwtSecret) });
+            }
+        }
+    }
+}

--- a/backend/CompanyService.Core/Web/Configurations/WebAppConfiguration.cs
+++ b/backend/CompanyService.Core/Web/Configurations/WebAppConfiguration.cs
@@ -7,7 +7,8 @@ namespace CompanyService.Core.Web.Configurations
     {
         public string BasePath { get; init; } = string.Empty;
 
-        public bool AuthenticationEnabled { get; init; }
+        [RequiredWithNested]
+        public AuthConfiguration AuthConfiguration { get; init; } 
 
         [RequiredWithNested]
         public ApiConfiguration ApiConfiguration { get; init; }

--- a/backend/CompanyService.Domain/Errors/CompanyError.cs
+++ b/backend/CompanyService.Domain/Errors/CompanyError.cs
@@ -34,5 +34,9 @@ namespace CompanyService.Domain.Errors
         public static CompanyError InvalidExchange => new (CompanyErrorCode.InvalidExchange);
 
         public static CompanyError UnknownExchange => new (CompanyErrorCode.UnknownExchange);
+
+        public static CompanyError InvalidClientCredentials => new (CompanyErrorCode.InvalidClientCredentials);
+
+        public static CompanyError AuthDisabled => new (CompanyErrorCode.AuthDisabled);
     }
 }

--- a/backend/CompanyService.Domain/Errors/CompanyErrorCode.cs
+++ b/backend/CompanyService.Domain/Errors/CompanyErrorCode.cs
@@ -19,5 +19,8 @@
         // Stock Exchange ISO 10383-Specific Errors
         InvalidExchange,             // Exchange field is empty or null
         UnknownExchange,             // Provided MIC code is not in the list
+
+        InvalidClientCredentials,    // Client ID or secret is invalid
+        AuthDisabled,                // Authentication is disabled
     }
 }


### PR DESCRIPTION
- Implemented `TokenService` to encapsulate JWT generation logic
- Added `MachineClients` for in-memory client validation (for simplicity)
- Updated `AuthController` to delegate authentication logic to `TokenService`
- Configured JWT secret via `WebAppConfiguration` to allow toggling authentication
- Secured API endpoints using `[Authorize]` attribute

This is a minimal M2M authentication setup to keep the project simple while demonstrating a practical approach. In a real-world scenario, client validation would be done via a database or external identity provider.